### PR TITLE
Added Firebase Hosting Targets

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,7 @@
 {
-  "hosting": {
+  "hosting": [{
     "public": "build",
+    "target": "prod",
     "ignore": [
       "firebase.json",
       "**/.*",
@@ -12,5 +13,20 @@
         "destination": "/index.html"
       }
     ]
-  }
+  },
+   {
+    "public": "build",
+    "target": "new-design",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }]
 }

--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ function App() {
     <div className="app">
       <BrowserRouter>
         <Switch>
-          <Route path="/" component={Homepage} />
+          <Route exact path="/" component={Homepage} />
           <Route exact path="/home" component={Homepage} />
           <Route exact path="/profile" component={Homepage} />
           <Route exact path="/upload" component={Homepage} />


### PR DESCRIPTION
I made some changes to Firebase Hosting:
https://recess-it.web.app is our prod link now

You can use `firebase deploy --only hosting:prod` in order to deploy site to the above link.

https://recess-it-new.web.app is the new-design target now

If you want, for preview of a beta version, we can create a separate target for it too. I haven't yet deployed the changes to `prod`, waiting for @avinashkranjan's permission, I did see a PR getting merged for a github action to do that, but it's still not effective. I'll make a new PR for firebase, so that the commands
`firebase deploy --only hosting:prod` for production release
`firebase deploy --only hosting:new-design` for new-design testing release
Work for every collaborator on firebase.